### PR TITLE
Recreate SettingsActivity on theme change

### DIFF
--- a/src/main/java/trikita/talalarmo/SettingsActivity.java
+++ b/src/main/java/trikita/talalarmo/SettingsActivity.java
@@ -69,6 +69,7 @@ public class SettingsActivity extends Activity
                     e.printStackTrace();
                 }
                 App.dispatch(new Action<>(Actions.Settings.SET_THEME, themeIndex));
+                recreate();
                 break;
         }
     }


### PR DESCRIPTION
Makes the theme change apply immediately, instead of when you return to the main activity.